### PR TITLE
fix KP on startup with NUC8i7BEH on 10.14.1

### DIFF
--- a/IntelMausiEthernet/IntelMausiSetup.cpp
+++ b/IntelMausiEthernet/IntelMausiSetup.cpp
@@ -469,9 +469,11 @@ void IntelMausi::clearDescriptors()
      * we must restore them in order to make sure that we leave the ring in
      * a usable state.
      */
-    for (i = 0; i < kNumRxDesc; i++) {
-        rxDescArray[i].read.buffer_addr = OSSwapHostToLittleInt64(rxBufArray[i].phyAddr);
-        rxDescArray[i].read.reserved = 0;
+    if (rxDescArray) {
+        for (i = 0; i < kNumRxDesc; i++) {
+            rxDescArray[i].read.buffer_addr = OSSwapHostToLittleInt64(rxBufArray[i].phyAddr);
+            rxDescArray[i].read.reserved = 0;
+        }
     }
     rxCleanedCount = rxNextDescIndex = 0;
 


### PR DESCRIPTION
Just ran into this after updating to 10.14.1 on my NUC8i7BEH ("Bean Canyon" Intel NUC).
The KP call stack indicated KP from clearDescriptors, called from intelRestart.

It is possible this only happens on an update from 10.14.0->10.14.1 if you have manually configured at 100baseT (there were some issues with automatic at 1000baseT, so I had changed it to manual).

This change fixed the problem.  Should be a safe fix, as in if rxDescArray is NULL, we definitely don't want to de-reference it in any case.